### PR TITLE
feat: AttributeInstance API improvements

### DIFF
--- a/src/main/java/net/minestom/server/entity/attribute/AttributeInstance.java
+++ b/src/main/java/net/minestom/server/entity/attribute/AttributeInstance.java
@@ -96,31 +96,40 @@ public final class AttributeInstance {
      * Add a modifier to this instance.
      *
      * @param modifier the modifier to add
+     * @return the old modifier, or null if none
      */
-    public void addModifier(@NotNull AttributeModifier modifier) {
-        if (modifiers.putIfAbsent(modifier.id(), modifier) == null) {
+    public AttributeModifier addModifier(@NotNull AttributeModifier modifier) {
+        final AttributeModifier old = modifiers.putIfAbsent(modifier.id(), modifier);
+        if (old == null) {
             refreshCachedValue();
         }
+
+        return old;
     }
 
     /**
      * Remove a modifier from this instance.
      *
      * @param modifier the modifier to remove
+     * @return the modifier that was removed, or null if none
      */
-    public void removeModifier(@NotNull AttributeModifier modifier) {
-        removeModifier(modifier.id());
+    public AttributeModifier removeModifier(@NotNull AttributeModifier modifier) {
+        return removeModifier(modifier.id());
     }
 
     /**
      * Remove a modifier from this instance.
      *
      * @param id The namespace id of the modifier to remove
+     * @return the modifier that was removed, or null if none
      */
-    public void removeModifier(@NotNull NamespaceID id) {
-        if (modifiers.remove(id) != null) {
+    public AttributeModifier removeModifier(@NotNull NamespaceID id) {
+        final AttributeModifier removed = modifiers.remove(id);
+        if (removed != null) {
             refreshCachedValue();
         }
+
+        return removed;
     }
 
     /**
@@ -133,11 +142,18 @@ public final class AttributeInstance {
     }
 
     /**
-     * Recalculate the value of this attribute instance using the modifiers.
+     * Gets the value of this instance, calculated assuming the given {@code baseValue}.
+     *
+     * @param baseValue the value to be used as the base for this operation, rather than this instance's normal base
+     *                  value
+     * @return the attribute value
      */
-    private void refreshCachedValue() {
+    public double getValueWithBase(double baseValue) {
+        return computeValue(baseValue);
+    }
+
+    private double computeValue(double base) {
         final Collection<AttributeModifier> modifiers = getModifiers();
-        double base = getBaseValue();
 
         for (var modifier : modifiers.stream().filter(mod -> mod.operation() == AttributeOperation.ADD_VALUE).toArray(AttributeModifier[]::new)) {
             base += modifier.amount();
@@ -152,7 +168,14 @@ public final class AttributeInstance {
             result *= (1.0f + modifier.amount());
         }
 
-        this.cachedValue = Math.clamp(result, getAttribute().minValue(), getAttribute().maxValue());
+        return Math.clamp(result, getAttribute().minValue(), getAttribute().maxValue());
+    }
+
+    /**
+     * Recalculate the value of this attribute instance using the modifiers.
+     */
+    private void refreshCachedValue() {
+        this.cachedValue = computeValue(getBaseValue());
 
         // Signal entity
         if (propertyChangeListener != null) {


### PR DESCRIPTION
Some small non-breaking changes to AttributeInstance:
* `addModifier(AttributeModifier)` returns the modifier that was replaced by the new one, or null if none exists
* Both `removeModifier(AttributeModifier)` and `removeModifier(NamespaceID)` return the modifier that was removed, or null if none was removed
* New method, `getValueWithBase(double)` for computing what the value of the AttributeInstance would be if it had a given base, without actually needing to set the base 

Justification:
* First two changes are mostly self-explanatory, it's useful to be able to know what a modifier did if you're removing or replacing it.
* Last change is useful for custom attributes that don't have a set "base value" that needs to be stored. For example, a damage type resistance API where the "base value" is just the damage that's being received, which is then dynamically modified based on AttributeModifiers.